### PR TITLE
WIP: Expansion of ASC 0

### DIFF
--- a/source/asc_list/asc000.rst
+++ b/source/asc_list/asc000.rst
@@ -6,11 +6,20 @@ AWDE Standards Core Standard
 :ASC: 0
 :Status: Proposed
 :Created: 2018-11-09
-:Version: 0
+:Updated: 2018-11-10
+:Version: 0.1
 :Authors:
          - Darkar
+         - WildfireXIII
 
 ----------------------------------------------------------------------------------------------------
+
+Abstract
+----------------------------------------------------------------------------------------------------
+
+This document specifies the standards and conventions to utilize when writing and publishing an ASC.
+This specification includes layout, organization, language style, technical requirements, and the
+philosophy of this proposed system.
 
 .. contents:: Table of Contents
 
@@ -137,3 +146,5 @@ ASCs should be written in American English. As of this moment there is no style 
 they should demonstrate correct grammer and spelling, they should be written in a formal tone which
 mimics the tone of RFCs, and aside from the 'epistemic status' and 'motivation' subsections should
 be written in third-person passive.
+
+.. vim: set tw=100 ts=4 sw=4 sts=4 et:

--- a/source/asc_list/asc000.rst
+++ b/source/asc_list/asc000.rst
@@ -16,7 +16,6 @@ AWDE Standards Core Standard
 
 Abstract
 ----------------------------------------------------------------------------------------------------
-
 This document specifies the standards and conventions to utilize when writing and publishing an ASC.
 This specification includes layout, organization, language style, technical requirements, and the
 philosophy of this proposed system.
@@ -25,15 +24,27 @@ philosophy of this proposed system.
 
 Introduction
 ----------------------------------------------------------------------------------------------------
+Throughout AWDE's history, the start of every new project has involved, to varying degrees,
+designing systems of planning for that particular project or simply not using a planning system at
+all. This lack of convention and wasted overhead in determining a planning system on the fly has led
+to multiple issues. In most every project, it has largely been unclear to what extent plans need
+actually be made, in both length, content, and organization. This has, in most cases, led to
+insufficient, irrelevant, or even inconsistent planning documentation. 
 
-This is the ASC which describes the standards system itself, including the layout and techical
-specifications for ASC documents and the process for updating old ASCs or integrating new ones into
-the standard.
+However, there have still been commonalities throughout most of these projects - the recognition of
+needing a sufficient set of plans, standards, protocols, and documentation to begin with, as well as
+some specific aspects such as code syntax conventions, a brainstorming or dump document, etc.
+
+The goal and philosophy then of the AWDE Standards Core is to provide a collection of precisely 
+defined and well documented protocols, conventions, and system specifications to be utilized in 
+future work, in order to have more consistent/less ambiguous approaches to projects.
 
 Motivation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-We want to keep things organized and standardized with the ASC system so it only makes sense to
-apply this reasoning to the ASC system itself.
+In keeping with the spirit of the ASC philosophy, there should exist a standard that defines how to
+approach defining future standards and protocols within the ASC system itself, and a defined
+protocol for the creation, review, and revisement of documents, up to the eventual acceptance into 
+or rejection from the ASC.
 
 Epistemic Status
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I'm working on expanding some of the content in ASC 0. In particular, I think we might want the introduction section (on this and future documents) to contain a decent amount of background on the problem, and then, like in RFC, put an abstract above the TOC with a short description of the document.

(Don't merge this yet, I'll continue to expand on some of the sections. Submitting a PR now so that I can become more familiar with the PR process, as well as initiating a discussion point for ASC 0.)